### PR TITLE
書籍リスト情報の取得

### DIFF
--- a/Module_books.bas
+++ b/Module_books.bas
@@ -1,12 +1,14 @@
 Attribute VB_Name = "Module_books"
 Option Explicit
 
+
 Sub getBookdata()
-    'URL取得
+    '旧コメント削除
+
     Dim objIE As InternetExplorer 'IEオブジェクトを準備
     Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
     
-    objIE.Visible = False 'IEを表示
+    objIE.Visible = False 'IEを表示、FalseでIE表示なし
     
     objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IEでURLを開く
     
@@ -14,84 +16,43 @@ Sub getBookdata()
 
     Dim htmlDoc As HTMLDocument 'HTMLドキュメントオブジェクトを準備
     Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
-    
-    'メッセージボックスに取得クラスの最初の文字を出力
-'    MsgBox htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("list-book-title").innerHTML
-'    Cells(2, 2).Value = htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-
-    ' シート上に指定クラスの全取得テキストを表示
-'    Dim Str As Object
-''    Dim i As Integer
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-'        Debug.Print "出力：" & Str.innerHTML
-'    Next Str
-
-'     メッセージボックスに取得クラスの子要素を取得出力
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("list-book-detail")(0).innerHTML
-
-
-'    クラス名内の要素配下のタグ名の中身を取得
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0).innerHTML
-
-
-'    クラス名内の要素配下のaタグ要素を取得(URL)
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
-
-
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML.getElementsByTagName("a")
-    
+  
 ''    データ取得まとめ
 '    Debug.Print "1." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
 '    Debug.Print "2." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
 '    Debug.Print "3." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("h3")
 '    Debug.Print "4." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("p")
     
-    
-    ' イミディエイトに指定クラスの全取得テキストを表示
-'    Dim Str As Variant
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-''        Debug.Print "出力：" & Str.innerHTML
-'    Next Str
 
-
-
-
-'    ' シート上に指定クラスの全取得テキストを表示
+    ' シート上に指定クラスの全取得テキストを表示
     Dim Str As Object
     Dim i As Integer
+    
+    'タイトル名取得
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-title")
         Worksheets("スクレイピング").Cells(i + 1, 1).Value = i
         Worksheets("スクレイピング").Cells(i + 1, 2).Value = Str.innerHTML
         i = i + 1
-'        Debug.Print "出力：" & Str.innerHTML
     Next Str
 
-'    i = 1
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-'        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
-'        i = i + 1
-'    Next Str
+    'detail取得
+    i = 1
+    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
+        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
+        i = i + 1
+    Next Str
 
-'    i = 1
-''    htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
-''    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-'    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
-'        Worksheets("スクレイピング").Cells(i + 1, 4).Value = Str.getElementsByTagName("a")
-'        i = i + 1
-'    Next Str
-
-
-'book-table__list--detail
-
+    'URL取得
+    i = 1
+    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
+        Worksheets("スクレイピング").Cells(i + 1, 4).Value = Str.getElementsByTagName("a")
+        i = i + 1
+    Next Str
 
     objIE.Quit 'objIEを終了させる
-'    Debug.Print "データ取得が完了しました。"
+    MsgBox "データ取得が完了しました。"
+
 End Sub
 Sub WaitResponse(objIE As Object)
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -3,60 +3,140 @@ Option Explicit
 
 
 Sub getBookdata()
-    '‹ŒƒRƒƒ“ƒgíœ
+    Dim objIE As InternetExplorer 'IEã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æº–å‚™
+    Set objIE = CreateObject("Internetexplorer.Application") 'æ–°ã—ã„IEã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’ä½œæˆã—ã¦ã‚»ãƒƒãƒˆ
+    objIE.Visible = True 'IEã‚’è¡¨ç¤º
+    objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IEã§URLã‚’é–‹ã
+    
+    Call WaitResponse(objIE) 'èª­ã¿è¾¼ã¿å¾…ã¡
+    
+    Dim htmlDoc As HTMLDocument 'HTMLãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æº–å‚™
+    Set htmlDoc = objIE.document 'objIEã§èª­ã¿è¾¼ã¾ã‚Œã¦ã„ã‚‹HTMLãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚’ã‚»ãƒƒãƒˆ
+    
+'    test = htmlDoc.getElementsByClassName("list-book-title")
+    
+'     ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã«å–å¾—ã‚¯ãƒ©ã‚¹ã®æœ€åˆã®æ–‡å­—ã‚’å‡ºåŠ›
+'    MsgBox htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
+    
+'     ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã«å–å¾—ã‚¯ãƒ©ã‚¹ã®å­è¦ç´ ã‚’å–å¾—å‡ºåŠ›
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("list-book-detail")(0).innerHTML
 
-    Dim objIE As InternetExplorer 'IEƒIƒuƒWƒFƒNƒg‚ğ€”õ
-    Set objIE = CreateObject("Internetexplorer.Application") 'V‚µ‚¢IEƒIƒuƒWƒFƒNƒg‚ğì¬‚µ‚ÄƒZƒbƒg
-    
-    objIE.Visible = False 'IE‚ğ•\¦AFalse‚ÅIE•\¦‚È‚µ
-    
-    objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IE‚ÅURL‚ğŠJ‚­
-    
-    Call WaitResponse(objIE) '“Ç‚İ‚İ‘Ò‚¿
 
-    Dim htmlDoc As HTMLDocument 'HTMLƒhƒLƒ…ƒƒ“ƒgƒIƒuƒWƒFƒNƒg‚ğ€”õ
-    Set htmlDoc = objIE.document 'objIE‚Å“Ç‚İ‚Ü‚ê‚Ä‚¢‚éHTMLƒhƒLƒ…ƒƒ“ƒg‚ğƒZƒbƒg
-  
-''    ƒf[ƒ^æ“¾‚Ü‚Æ‚ß
+
+
+'    ã‚¯ãƒ©ã‚¹åå†…ã®è¦ç´ é…ä¸‹ã®ã‚¿ã‚°åã®ä¸­èº«ã‚’å–å¾—
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0).innerHTML
+
+
+
+
+'    ã‚¯ãƒ©ã‚¹åå†…ã®è¦ç´ é…ä¸‹ã®aã‚¿ã‚°è¦ç´ ã‚’å–å¾—(URL)
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
+
+
+
+
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML.getElementsByTagName("a")
+    
+'    ãƒ‡ãƒ¼ã‚¿å–å¾—ã¾ã¨ã‚
 '    Debug.Print "1." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
 '    Debug.Print "2." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
 '    Debug.Print "3." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("h3")
 '    Debug.Print "4." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("p")
     
-
-    ' ƒV[ƒgã‚Éw’èƒNƒ‰ƒX‚Ì‘Sæ“¾ƒeƒLƒXƒg‚ğ•\¦
-    Dim Str As Object
-    Dim i As Integer
     
-    'ƒ^ƒCƒgƒ‹–¼æ“¾
+    ' ã‚¤ãƒŸãƒ‡ã‚£ã‚¨ã‚¤ãƒˆã«æŒ‡å®šã‚¯ãƒ©ã‚¹ã®å…¨å–å¾—ãƒ†ã‚­ã‚¹ãƒˆã‚’è¡¨ç¤º
+'    Dim Str As Variant
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
+''        Debug.Print "å‡ºåŠ›ï¼š" & Str.innerHTML
+'    Next Str
+
+
+
+
+'    test = htmlDoc.getElementsByClassName("list-book-title")
+'    Debug.Print UBound(test, 2)
+
+
+
+
+
+
+
+
+''    ' ã‚·ãƒ¼ãƒˆä¸Šã«æŒ‡å®šã‚¯ãƒ©ã‚¹ã®å…¨å–å¾—ãƒ†ã‚­ã‚¹ãƒˆã‚’è¡¨ç¤º
+    Dim Str As Variant
+    Dim i As Integer
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 1).Value = i
-        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 2).Value = Str.innerHTML
+'        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 1).Value = i
+        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 2).Value = Str.innerHTML
         i = i + 1
+'        Debug.Print "å‡ºåŠ›ï¼š" & Str.innerHTML
     Next Str
 
-    'detailæ“¾
+
+    'æ›¸ç±è©³ç´°
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 3).Value = Str.innerHTML
+        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 3).Value = Str.innerHTML
         i = i + 1
     Next Str
 
-    'URLæ“¾
+
+'    i = 1
+'    Dim Arr As Variant
+'    ReDim Arr(20)
+'    Arr = htmlDoc.getElementsByClassName("list-book-detail")
+'    Range("A2").Value = Arr
+
+
+    'URL
     i = 1
+'    htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
+    Dim GetUrl As String
+    Dim GetUrlData() As String
+    Dim GetUrlElement As Integer
+    Dim GetID As Integer
+    
     For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
-        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 4).Value = Str.getElementsByTagName("a")
-        i = i + 1
+        GetUrl = Str.getElementsByTagName("a")  'URLå–å¾—
+        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 4).Value = GetUrl  'å–å¾—URLåæ˜ 
+        GetUrlData = Split(GetUrl, "/")  'URLè¦ç´ å–å¾—
+        GetUrlElement = UBound(GetUrlData)  'URLè¦ç´ ç¢ºèª
+        GetID = GetUrlData(GetUrlElement)  'URLã‹ã‚‰ç•ªå·å–å¾—
+        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 1).Value = GetID  'ãƒ¯ãƒ¼ã‚¯ã‚·ãƒ¼ãƒˆã¸åæ˜ 
+        i = i + 1  'æ¬¡ã®è¡ŒæŒ‡å®š
     Next Str
 
-    objIE.Quit 'objIE‚ğI—¹‚³‚¹‚é
-    MsgBox "ƒf[ƒ^æ“¾‚ªŠ®—¹‚µ‚Ü‚µ‚½B"
 
+'    Dim test As String
+''    test = "aa/bb/cc/dd"
+'    test = "https://protected-fortress-61913.herokuapp.com/book"
+'    test2 = Split(test, "/")
+'    Debug.Print test
+'    Debug.Print test2(0)
+'    Debug.Print test2(1)
+'    Debug.Print test2(2)
+'    Debug.Print test2(3)
+'    Debug.Print UBound(test2)
+
+
+'book-table__list--detail
+
+
+
+
+    objIE.Quit 'objIEã‚’çµ‚äº†ã•ã›ã‚‹
+    Debug.Print "ãƒ‡ãƒ¼ã‚¿å–å¾—ãŒå®Œäº†ã—ã¾ã—ãŸã€‚"
 End Sub
 Sub WaitResponse(objIE As Object)
-    Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '“Ç‚İ‚İ‘Ò‚¿
+    Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE 'èª­ã¿è¾¼ã¿å¾…ã¡
         DoEvents
     Loop
 End Sub
-

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -2,32 +2,67 @@ Attribute VB_Name = "Module_books"
 Option Explicit
 
 Sub getBookdata()
-    'ベース作成+セル表示
+    'URL取得
     Dim objIE As InternetExplorer 'IEオブジェクトを準備
     Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
-
-    objIE.Visible = True 'IEを表示
-
+    
+    objIE.Visible = False 'IEを表示
+    
     objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IEでURLを開く
-
+    
     Call WaitResponse(objIE) '読み込み待ち
 
     Dim htmlDoc As HTMLDocument 'HTMLドキュメントオブジェクトを準備
     Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
-
+    
     'メッセージボックスに取得クラスの最初の文字を出力
-'     MsgBox htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-    
-    
-    'イミディエイトに指定クラスの全取得テキストを表示
-'    Dim Str As Variant
+'    MsgBox htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("list-book-title").innerHTML
+'    Cells(2, 2).Value = htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
+
+    ' シート上に指定クラスの全取得テキストを表示
+'    Dim Str As Object
+''    Dim i As Integer
 '    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
 '        Debug.Print "出力：" & Str.innerHTML
 '    Next Str
+
+'     メッセージボックスに取得クラスの子要素を取得出力
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("list-book-detail")(0).innerHTML
+
+
+'    クラス名内の要素配下のタグ名の中身を取得
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0).innerHTML
+
+
+'    クラス名内の要素配下のaタグ要素を取得(URL)
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
+
+
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
+'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML.getElementsByTagName("a")
+    
+''    データ取得まとめ
+'    Debug.Print "1." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
+'    Debug.Print "2." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
+'    Debug.Print "3." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("h3")
+'    Debug.Print "4." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("p")
     
     
-    'シート上に指定クラスの全取得テキストを表示
-    Dim Str As Variant
+    ' イミディエイトに指定クラスの全取得テキストを表示
+'    Dim Str As Variant
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
+''        Debug.Print "出力：" & Str.innerHTML
+'    Next Str
+
+
+
+
+'    ' シート上に指定クラスの全取得テキストを表示
+    Dim Str As Object
     Dim i As Integer
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-title")
@@ -36,20 +71,30 @@ Sub getBookdata()
         i = i + 1
 '        Debug.Print "出力：" & Str.innerHTML
     Next Str
-    
-    i = 1
-    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
-        i = i + 1
-    Next Str
-'    Debug.Print "データ取得が完了しました。"
-'    objIE.Quit
-End Sub
 
+'    i = 1
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
+'        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
+'        i = i + 1
+'    Next Str
+
+'    i = 1
+''    htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
+''    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
+'    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
+'        Worksheets("スクレイピング").Cells(i + 1, 4).Value = Str.getElementsByTagName("a")
+'        i = i + 1
+'    Next Str
+
+
+'book-table__list--detail
+
+
+    objIE.Quit 'objIEを終了させる
+'    Debug.Print "データ取得が完了しました。"
+End Sub
 Sub WaitResponse(objIE As Object)
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
-'        Debug.Print objIE.Busy
-'        Debug.Print objIE.readyState
         DoEvents
     Loop
 End Sub

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -5,7 +5,7 @@ Option Explicit
 Sub getBookdata()
     Dim objIE As InternetExplorer 'IEオブジェクトを準備
     Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
-    objIE.Visible = True 'IEを表示
+    objIE.Visible = False 'IEを表示
     objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IEでURLを開く
     
     Call WaitResponse(objIE) '読み込み待ち
@@ -47,109 +47,36 @@ Sub getBookdata()
         i = i + 1  '次の行指定
     Next Str
 
-
-
-    '画像URL取得
-    
     '画像用変数
     Dim imgURL As String '画像URL
     Dim Img As Object '画像オブジェクト
-    Dim toppix As Long '位置ピクセル
-
-'    '1個をサンプル取得
-'    imgURL = htmlDoc.images(0).src
-'    Worksheets("スクレイピング").Cells(2, 5).Value = imgURL
-'    Worksheets("スクレイピング").Shapes.AddPicture _
-'        fileName:=imgURL, _
-'            LinkToFile:=True, _
-'                SaveWithDocument:=True, _
-'                Left:=0, _
-'                Top:=0, _
-'                Width:=100, _
-'                Height:=80
-    
-'    'URLのみ取得
-'    i = 1
-'    For Each IMG In htmlDoc.images 'イメージ取得
-'        imgURL = IMG.src '変数格納
-'        Worksheets("スクレイピング").Cells(i + 1, 5).Value = imgURL '取得URL反映
-'        i = i + 1
-'    Next IMG
-    
-    
-    
-    Dim ActCell As Object
+    Dim ActCell As Object '画像出力セル
 
     i = 1
-    toppix = 0
-    For Each Img In htmlDoc.images 'イメージ取得
-        imgURL = Img.src '変数格納
+    
+    For Each Img In htmlDoc.images '画像要素取得
+        imgURL = Img.src '画像URL
         Set ActCell = Worksheets("スクレイピング").Cells(i + 1, 5)
-        ActCell.Value = imgURL  '取得URL反映
 
-        '画像を表示
+        '画像出力セルのピクセルを指定して表示
         Worksheets("スクレイピング").Shapes.AddPicture _
             fileName:=imgURL, _
                 LinkToFile:=True, _
                     SaveWithDocument:=True, _
-                    Left:=0, _
-                    Top:=0 + toppix, _
+                    Left:=ActCell.Left, _
+                    Top:=ActCell.Top, _
                     Width:=100, _
                     Height:=100
 
-'        '画像を表示、セルピクセル取得
-'        Worksheets("スクレイピング").Shapes.AddPicture _
-'            fileName:=imgURL, _
-'                LinkToFile:=True, _
-'                    SaveWithDocument:=True, _
-'                    Left:=ActCell.Left, _
-'                    Top:=ActCell.Top, _
-'                    Width:=100, _
-'                    Height:=100
-
         i = i + 1
-        toppix = toppix + 100
     Next Img
 
 
     objIE.Quit 'objIEを終了させる
     MsgBox "データ取得が完了しました。"
 End Sub
-Sub WaitResponse(objIE As Object)
+Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
         DoEvents
     Loop
-End Sub
-Sub picture1()
-    'ローカルディスク上の画像ファイルを表示
-    Worksheets("スクレイピング").Shapes.AddPicture _
-        fileName:="Z:\FierVega\ariawase-master\bin\test.jpg", _
-            LinkToFile:=True, _
-                SaveWithDocument:=True, _
-                Left:=0, _
-                Top:=0, _
-                Width:=100, _
-                Height:=80
-End Sub
-Sub picture2()
-    'coverURLを指定してファイル表示
-    Worksheets("スクレイピング").Shapes.AddPicture _
-        fileName:="https://cover.openbd.jp/9784797398892.jpg", _
-            LinkToFile:=True, _
-                SaveWithDocument:=True, _
-                Left:=0, _
-                Top:=0, _
-                Width:=100, _
-                Height:=80
-End Sub
-Sub picture3()
-    'coverURLを指定してファイル表示
-    Worksheets("スクレイピング").Shapes.AddPicture _
-        fileName:="https://cover.openbd.jp/9784797398892.jpg", _
-            LinkToFile:=True, _
-                SaveWithDocument:=True, _
-                Left:=330, _
-                Top:=40, _
-                Width:=100, _
-                Height:=80
 End Sub

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -3,140 +3,153 @@ Option Explicit
 
 
 Sub getBookdata()
-    Dim objIE As InternetExplorer 'IEã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æº–å‚™
-    Set objIE = CreateObject("Internetexplorer.Application") 'æ–°ã—ã„IEã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’ä½œæˆã—ã¦ã‚»ãƒƒãƒˆ
-    objIE.Visible = True 'IEã‚’è¡¨ç¤º
-    objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IEã§URLã‚’é–‹ã
+    Dim objIE As InternetExplorer 'IEƒIƒuƒWƒFƒNƒg‚ğ€”õ
+    Set objIE = CreateObject("Internetexplorer.Application") 'V‚µ‚¢IEƒIƒuƒWƒFƒNƒg‚ğì¬‚µ‚ÄƒZƒbƒg
+    objIE.Visible = True 'IE‚ğ•\¦
+    objIE.navigate "https://protected-fortress-61913.herokuapp.com/book" 'IE‚ÅURL‚ğŠJ‚­
     
-    Call WaitResponse(objIE) 'èª­ã¿è¾¼ã¿å¾…ã¡
+    Call WaitResponse(objIE) '“Ç‚İ‚İ‘Ò‚¿
     
-    Dim htmlDoc As HTMLDocument 'HTMLãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚ªãƒ–ã‚¸ã‚§ã‚¯ãƒˆã‚’æº–å‚™
-    Set htmlDoc = objIE.document 'objIEã§èª­ã¿è¾¼ã¾ã‚Œã¦ã„ã‚‹HTMLãƒ‰ã‚­ãƒ¥ãƒ¡ãƒ³ãƒˆã‚’ã‚»ãƒƒãƒˆ
+    Dim htmlDoc As HTMLDocument 'HTMLƒhƒLƒ…ƒƒ“ƒgƒIƒuƒWƒFƒNƒg‚ğ€”õ
+    Set htmlDoc = objIE.document 'objIE‚Å“Ç‚İ‚Ü‚ê‚Ä‚¢‚éHTMLƒhƒLƒ…ƒƒ“ƒg‚ğƒZƒbƒg
     
-'    test = htmlDoc.getElementsByClassName("list-book-title")
-    
-'     ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã«å–å¾—ã‚¯ãƒ©ã‚¹ã®æœ€åˆã®æ–‡å­—ã‚’å‡ºåŠ›
-'    MsgBox htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("list-book-title")(0).innerHTML
-    
-'     ãƒ¡ãƒƒã‚»ãƒ¼ã‚¸ãƒœãƒƒã‚¯ã‚¹ã«å–å¾—ã‚¯ãƒ©ã‚¹ã®å­è¦ç´ ã‚’å–å¾—å‡ºåŠ›
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("list-book-detail")(0).innerHTML
-
-
-
-
-'    ã‚¯ãƒ©ã‚¹åå†…ã®è¦ç´ é…ä¸‹ã®ã‚¿ã‚°åã®ä¸­èº«ã‚’å–å¾—
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0).innerHTML
-
-
-
-
-'    ã‚¯ãƒ©ã‚¹åå†…ã®è¦ç´ é…ä¸‹ã®aã‚¿ã‚°è¦ç´ ã‚’å–å¾—(URL)
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
-
-
-
-
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
-'    Debug.Print htmlDoc.getElementsByClassName("book-table__list--detail")(0).outerHTML.getElementsByTagName("a")
-    
-'    ãƒ‡ãƒ¼ã‚¿å–å¾—ã¾ã¨ã‚
-'    Debug.Print "1." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).innerHTML
-'    Debug.Print "2." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")
-'    Debug.Print "3." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("h3")
-'    Debug.Print "4." & htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("p")
-    
-    
-    ' ã‚¤ãƒŸãƒ‡ã‚£ã‚¨ã‚¤ãƒˆã«æŒ‡å®šã‚¯ãƒ©ã‚¹ã®å…¨å–å¾—ãƒ†ã‚­ã‚¹ãƒˆã‚’è¡¨ç¤º
-'    Dim Str As Variant
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-''        Debug.Print "å‡ºåŠ›ï¼š" & Str.innerHTML
-'    Next Str
-
-
-
-
-'    test = htmlDoc.getElementsByClassName("list-book-title")
-'    Debug.Print UBound(test, 2)
-
-
-
-
-
-
-
-
-''    ' ã‚·ãƒ¼ãƒˆä¸Šã«æŒ‡å®šã‚¯ãƒ©ã‚¹ã®å…¨å–å¾—ãƒ†ã‚­ã‚¹ãƒˆã‚’è¡¨ç¤º
-    Dim Str As Variant
+    ' ƒV[ƒgã‚Éw’èƒNƒ‰ƒX‚Ì‘Sæ“¾ƒeƒLƒXƒg‚ğ•\¦
+    Dim Str As Object
     Dim i As Integer
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-'        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 1).Value = i
-        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 2).Value = Str.innerHTML
+        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 2).Value = Str.innerHTML
         i = i + 1
-'        Debug.Print "å‡ºåŠ›ï¼š" & Str.innerHTML
     Next Str
 
-
-    'æ›¸ç±è©³ç´°
+    '‘ĞÚ×
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 3).Value = Str.innerHTML
+        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 3).Value = Str.innerHTML
         i = i + 1
     Next Str
-
-
-'    i = 1
-'    Dim Arr As Variant
-'    ReDim Arr(20)
-'    Arr = htmlDoc.getElementsByClassName("list-book-detail")
-'    Range("A2").Value = Arr
 
 
     'URL
     i = 1
-'    htmlDoc.getElementsByClassName("book-table__list--detail")(0).getElementsByTagName("a")(0)
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
     Dim GetUrl As String
     Dim GetUrlData() As String
     Dim GetUrlElement As Integer
     Dim GetID As Integer
     
     For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
-        GetUrl = Str.getElementsByTagName("a")  'URLå–å¾—
-        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 4).Value = GetUrl  'å–å¾—URLåæ˜ 
-        GetUrlData = Split(GetUrl, "/")  'URLè¦ç´ å–å¾—
-        GetUrlElement = UBound(GetUrlData)  'URLè¦ç´ ç¢ºèª
-        GetID = GetUrlData(GetUrlElement)  'URLã‹ã‚‰ç•ªå·å–å¾—
-        Worksheets("ã‚¹ã‚¯ãƒ¬ã‚¤ãƒ”ãƒ³ã‚°").Cells(i + 1, 1).Value = GetID  'ãƒ¯ãƒ¼ã‚¯ã‚·ãƒ¼ãƒˆã¸åæ˜ 
-        i = i + 1  'æ¬¡ã®è¡ŒæŒ‡å®š
+        GetUrl = Str.getElementsByTagName("a")  'URLæ“¾
+        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 4).Value = GetUrl  'æ“¾URL”½‰f
+        GetUrlData = Split(GetUrl, "/")  'URL—v‘fæ“¾
+        GetUrlElement = UBound(GetUrlData)  'URL—v‘fŠm”F
+        GetID = GetUrlData(GetUrlElement)  'URL‚©‚ç”Ô†æ“¾
+        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 1).Value = GetID  'ƒ[ƒNƒV[ƒg‚Ö”½‰f
+        i = i + 1  'Ÿ‚Ìsw’è
     Next Str
 
 
-'    Dim test As String
-''    test = "aa/bb/cc/dd"
-'    test = "https://protected-fortress-61913.herokuapp.com/book"
-'    test2 = Split(test, "/")
-'    Debug.Print test
-'    Debug.Print test2(0)
-'    Debug.Print test2(1)
-'    Debug.Print test2(2)
-'    Debug.Print test2(3)
-'    Debug.Print UBound(test2)
+
+    '‰æ‘œURLæ“¾
+    
+    '‰æ‘œ—p•Ï”
+    Dim imgURL As String '‰æ‘œURL
+    Dim Img As Object '‰æ‘œƒIƒuƒWƒFƒNƒg
+    Dim toppix As Long 'ˆÊ’uƒsƒNƒZƒ‹
+
+'    '1ŒÂ‚ğƒTƒ“ƒvƒ‹æ“¾
+'    imgURL = htmlDoc.images(0).src
+'    Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(2, 5).Value = imgURL
+'    Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+'        fileName:=imgURL, _
+'            LinkToFile:=True, _
+'                SaveWithDocument:=True, _
+'                Left:=0, _
+'                Top:=0, _
+'                Width:=100, _
+'                Height:=80
+    
+'    'URL‚Ì‚İæ“¾
+'    i = 1
+'    For Each IMG In htmlDoc.images 'ƒCƒ[ƒWæ“¾
+'        imgURL = IMG.src '•Ï”Ši”[
+'        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 5).Value = imgURL 'æ“¾URL”½‰f
+'        i = i + 1
+'    Next IMG
+    
+    
+    
+    Dim ActCell As Object
+
+    i = 1
+    toppix = 0
+    For Each Img In htmlDoc.images 'ƒCƒ[ƒWæ“¾
+        imgURL = Img.src '•Ï”Ši”[
+        Set ActCell = Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Cells(i + 1, 5)
+        ActCell.Value = imgURL  'æ“¾URL”½‰f
+
+        '‰æ‘œ‚ğ•\¦
+        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+            fileName:=imgURL, _
+                LinkToFile:=True, _
+                    SaveWithDocument:=True, _
+                    Left:=0, _
+                    Top:=0 + toppix, _
+                    Width:=100, _
+                    Height:=100
+
+'        '‰æ‘œ‚ğ•\¦AƒZƒ‹ƒsƒNƒZƒ‹æ“¾
+'        Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+'            fileName:=imgURL, _
+'                LinkToFile:=True, _
+'                    SaveWithDocument:=True, _
+'                    Left:=ActCell.Left, _
+'                    Top:=ActCell.Top, _
+'                    Width:=100, _
+'                    Height:=100
+
+        i = i + 1
+        toppix = toppix + 100
+    Next Img
 
 
-'book-table__list--detail
-
-
-
-
-    objIE.Quit 'objIEã‚’çµ‚äº†ã•ã›ã‚‹
-    Debug.Print "ãƒ‡ãƒ¼ã‚¿å–å¾—ãŒå®Œäº†ã—ã¾ã—ãŸã€‚"
+    objIE.Quit 'objIE‚ğI—¹‚³‚¹‚é
+    MsgBox "ƒf[ƒ^æ“¾‚ªŠ®—¹‚µ‚Ü‚µ‚½B"
 End Sub
 Sub WaitResponse(objIE As Object)
-    Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE 'èª­ã¿è¾¼ã¿å¾…ã¡
+    Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '“Ç‚İ‚İ‘Ò‚¿
         DoEvents
     Loop
+End Sub
+Sub picture1()
+    'ƒ[ƒJƒ‹ƒfƒBƒXƒNã‚Ì‰æ‘œƒtƒ@ƒCƒ‹‚ğ•\¦
+    Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+        fileName:="Z:\FierVega\ariawase-master\bin\test.jpg", _
+            LinkToFile:=True, _
+                SaveWithDocument:=True, _
+                Left:=0, _
+                Top:=0, _
+                Width:=100, _
+                Height:=80
+End Sub
+Sub picture2()
+    'coverURL‚ğw’è‚µ‚Äƒtƒ@ƒCƒ‹•\¦
+    Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+        fileName:="https://cover.openbd.jp/9784797398892.jpg", _
+            LinkToFile:=True, _
+                SaveWithDocument:=True, _
+                Left:=0, _
+                Top:=0, _
+                Width:=100, _
+                Height:=80
+End Sub
+Sub picture3()
+    'coverURL‚ğw’è‚µ‚Äƒtƒ@ƒCƒ‹•\¦
+    Worksheets("ƒXƒNƒŒƒCƒsƒ“ƒO").Shapes.AddPicture _
+        fileName:="https://cover.openbd.jp/9784797398892.jpg", _
+            LinkToFile:=True, _
+                SaveWithDocument:=True, _
+                Left:=330, _
+                Top:=40, _
+                Width:=100, _
+                Height:=80
 End Sub


### PR DESCRIPTION
# WHAT
書籍一覧情報をスクレイピングしてワークシートに一覧表示させる
## 書籍一覧情報取得コード
Module_books.bas

# WHY
book.indexページに表示される書籍情報の一覧をスクレイピングし、Excel上にデータを表示させる。
データID、タイトル名、詳細テキスト、詳細ページURL、表紙画像を対象としている。
画像表示に対してはAddPictureがセル番地指定ができないので、セルのピクセルを取得して表示させるようにした。

![VBA-スクレイピング27](https://user-images.githubusercontent.com/45278393/59154505-a9400b00-8aae-11e9-8593-96ca4e09c8b5.JPG)
