### PR TITLE
レコード単位で書籍リスト情報の取得

### DIFF
--- a/Module_books.bas
+++ b/Module_books.bas
@@ -13,61 +13,60 @@ Sub getBookdata()
     Dim htmlDoc As HTMLDocument 'HTMLドキュメントオブジェクトを準備
     Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
     
-    Dim Str As Object
+    Dim Bookdata As Object 'レコード単位データ
+    Dim detailField As Variant '詳細フィールドデータ
+    Dim GetUrl As String '詳細ページURL
+    Dim GetUrlData() As String '詳細ページURL,Splitデータ
+    Dim GetUrlElement As Integer 'URLSplit要素数
+    Dim GetID As Integer 'ID番号
+    
+    Dim imgURL As String '画像URL
+'    Dim imgURL As Variant '画像URL
+    Dim Img As Variant '画像オブジェクト
+    Dim ActCell As Object '画像出力セル
+    
     Dim i As Integer
     i = 1
     
     'レコード単位出力(テストシート)
     i = 1
-    For Each Str In htmlDoc.getElementsByClassName("book-table__list")
-        Worksheets("テスト").Cells(i + 1, 2).Value = Str.innerHTML
-        i = i + 1
-    Next Str
+    ' book-table__listの要素をBookdataとして処理
+    For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
     
-    ' シート上に指定クラスの全取得テキストを表示
-    i = 1
-    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-        Worksheets("スクレイピング").Cells(i + 1, 2).Value = Str.innerHTML
-        i = i + 1
-    Next Str
+        'Bookdata要素全体HTML
+        Worksheets("テスト").Cells(i + 1, 2).Value = Bookdata.innerHTML
+            
+        '--detail部を取得してそれぞれ反映
+            
+            detailField = Bookdata.getElementsByClassName("book-table__list--detail") '--detailを取得
+            
+            'タイトル名
+            Worksheets("テスト").Cells(i + 1, 3).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
+            
+            '詳細テキスト
+            Worksheets("テスト").Cells(i + 1, 4).Value = detailField.getElementsByClassName("list-book-detail")(0).innerText
+            
+            
+            '詳細ページURL
+            GetUrl = detailField.getElementsByTagName("a") 'URL取得
+            Worksheets("テスト").Cells(i + 1, 5).Value = GetUrl  '取得URL反映
+            GetUrlData = Split(GetUrl, "/")  'URL要素取得
+            GetUrlElement = UBound(GetUrlData)  'URL要素確認
+            GetID = GetUrlData(GetUrlElement)  'URLから番号取得
+            Worksheets("テスト").Cells(i + 1, 1).Value = GetID
+        
+        '--detail部を取得してそれぞれ反映ここまで
+        
+                
+        '画像処理
 
-    '書籍詳細
-    i = 1
-    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
-        i = i + 1
-    Next Str
-
-
-    'URL
-    Dim GetUrl As String
-    Dim GetUrlData() As String
-    Dim GetUrlElement As Integer
-    Dim GetID As Integer
-
-    i = 1
-    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
-        GetUrl = Str.getElementsByTagName("a")  'URL取得
-        Worksheets("スクレイピング").Cells(i + 1, 4).Value = GetUrl  '取得URL反映
-        GetUrlData = Split(GetUrl, "/")  'URL要素取得
-        GetUrlElement = UBound(GetUrlData)  'URL要素確認
-        GetID = GetUrlData(GetUrlElement)  'URLから番号取得
-        Worksheets("スクレイピング").Cells(i + 1, 1).Value = GetID  'ワークシートへ反映
-        i = i + 1  '次の行指定
-    Next Str
-
-    '画像用変数
-    Dim imgURL As String '画像URL
-    Dim Img As Object '画像オブジェクト
-    Dim ActCell As Object '画像出力セル
-
-    i = 1
-    For Each Img In htmlDoc.images '画像要素取得
+'        Img = Bookdata.images '画像取得
+        Img = Bookdata.getElementsByTagName("img")  '画像取得
         imgURL = Img.src '画像URL
-        Set ActCell = Worksheets("スクレイピング").Cells(i + 1, 5)
+        Set ActCell = Worksheets("テスト").Cells(i + 1, 6)
 
         '画像出力セルのピクセルを指定して表示
-        Worksheets("スクレイピング").Shapes.AddPicture _
+        Worksheets("テスト").Shapes.AddPicture _
             fileName:=imgURL, _
                 LinkToFile:=True, _
                     SaveWithDocument:=True, _
@@ -76,8 +75,67 @@ Sub getBookdata()
                     Width:=100, _
                     Height:=100
 
+        '画像処理ここまで
+        
+        
+        '次のレコードの行番号
         i = i + 1
-    Next Img
+    Next Bookdata
+    
+'    ' シート上に指定クラスの全取得テキストを表示
+'    i = 1
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
+'        Worksheets("スクレイピング").Cells(i + 1, 2).Value = Str.innerHTML
+'        i = i + 1
+'    Next Str
+'
+'    '書籍詳細
+'    i = 1
+'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
+'        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
+'        i = i + 1
+'    Next Str
+'
+'
+'    'URL
+'    Dim GetUrl As String
+'    Dim GetUrlData() As String
+'    Dim GetUrlElement As Integer
+'    Dim GetID As Integer
+'
+'    i = 1
+'    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
+'        GetUrl = Str.getElementsByTagName("a")  'URL取得
+'        Worksheets("スクレイピング").Cells(i + 1, 4).Value = GetUrl  '取得URL反映
+'        GetUrlData = Split(GetUrl, "/")  'URL要素取得
+'        GetUrlElement = UBound(GetUrlData)  'URL要素確認
+'        GetID = GetUrlData(GetUrlElement)  'URLから番号取得
+'        Worksheets("スクレイピング").Cells(i + 1, 1).Value = GetID  'ワークシートへ反映
+'        i = i + 1  '次の行指定
+'    Next Str
+'
+'    '画像用変数
+'    Dim imgURL As String '画像URL
+'    Dim Img As Object '画像オブジェクト
+'    Dim ActCell As Object '画像出力セル
+'
+'    i = 1
+'    For Each Img In htmlDoc.images '画像要素取得
+'        imgURL = Img.src '画像URL
+'        Set ActCell = Worksheets("スクレイピング").Cells(i + 1, 5)
+'
+'        '画像出力セルのピクセルを指定して表示
+'        Worksheets("スクレイピング").Shapes.AddPicture _
+'            fileName:=imgURL, _
+'                LinkToFile:=True, _
+'                    SaveWithDocument:=True, _
+'                    Left:=ActCell.Left, _
+'                    Top:=ActCell.Top, _
+'                    Width:=100, _
+'                    Height:=100
+'
+'        i = i + 1
+'    Next Img
 
 
     objIE.Quit 'objIEを終了させる

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -13,6 +13,11 @@ Sub getBookdata()
     Dim htmlDoc As HTMLDocument 'HTMLドキュメントオブジェクトを準備
     Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
     
+    '作業ワークシート指定
+    Dim SWSheet As Worksheet 'ScrapingWorksheet
+    Set SWSheet = ThisWorkbook.Worksheets("スクレイピング")
+    
+    
     Dim Bookdata As Object 'レコード単位データ
     Dim detailField As Variant '詳細フィールドデータ
     Dim GetUrl As String '詳細ページURL
@@ -28,32 +33,32 @@ Sub getBookdata()
     Dim i As Integer
     i = 1
     
-    'レコード単位出力(テストシート)
-    i = 1
+    
+    'レコード単位でデータ出力
     ' book-table__listの要素をBookdataとして処理
     For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
     
-        'Bookdata要素全体HTML
-        Worksheets("テスト").Cells(i + 1, 2).Value = Bookdata.innerHTML
+'        'Bookdata要素全体HTML(出力確認用)
+'        SWSheet.Cells(i + 1, 2).Value = Bookdata.innerHTML
             
         '--detail部を取得してそれぞれ反映
             
             detailField = Bookdata.getElementsByClassName("book-table__list--detail") '--detailを取得
             
             'タイトル名
-            Worksheets("テスト").Cells(i + 1, 3).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
+            SWSheet.Cells(i + 1, 2).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
             
             '詳細テキスト
-            Worksheets("テスト").Cells(i + 1, 4).Value = detailField.getElementsByClassName("list-book-detail")(0).innerText
+            SWSheet.Cells(i + 1, 3).Value = detailField.getElementsByClassName("list-book-detail")(0).innerText
             
             
             '詳細ページURL
             GetUrl = detailField.getElementsByTagName("a") 'URL取得
-            Worksheets("テスト").Cells(i + 1, 5).Value = GetUrl  '取得URL反映
+            SWSheet.Cells(i + 1, 4).Value = GetUrl  '取得URL反映
             GetUrlData = Split(GetUrl, "/")  'URL要素取得
             GetUrlElement = UBound(GetUrlData)  'URL要素確認
             GetID = GetUrlData(GetUrlElement)  'URLから番号取得
-            Worksheets("テスト").Cells(i + 1, 1).Value = GetID
+            SWSheet.Cells(i + 1, 1).Value = GetID
         
         '--detail部を取得してそれぞれ反映ここまで
         
@@ -63,10 +68,10 @@ Sub getBookdata()
 '        Img = Bookdata.images '画像取得
         Img = Bookdata.getElementsByTagName("img")  '画像取得
         imgURL = Img.src '画像URL
-        Set ActCell = Worksheets("テスト").Cells(i + 1, 6)
+        Set ActCell = SWSheet.Cells(i + 1, 5)
 
         '画像出力セルのピクセルを指定して表示
-        Worksheets("テスト").Shapes.AddPicture _
+        SWSheet.Shapes.AddPicture _
             fileName:=imgURL, _
                 LinkToFile:=True, _
                     SaveWithDocument:=True, _
@@ -80,6 +85,7 @@ Sub getBookdata()
         
         '次のレコードの行番号
         i = i + 1
+'        If i > 1 Then Exit For
     Next Bookdata
     
 '    ' シート上に指定クラスの全取得テキストを表示

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -13,9 +13,18 @@ Sub getBookdata()
     Dim htmlDoc As HTMLDocument 'HTMLドキュメントオブジェクトを準備
     Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
     
-    ' シート上に指定クラスの全取得テキストを表示
     Dim Str As Object
     Dim i As Integer
+    i = 1
+    
+    'レコード単位出力(テストシート)
+    i = 1
+    For Each Str In htmlDoc.getElementsByClassName("book-table__list")
+        Worksheets("テスト").Cells(i + 1, 2).Value = Str.innerHTML
+        i = i + 1
+    Next Str
+    
+    ' シート上に指定クラスの全取得テキストを表示
     i = 1
     For Each Str In htmlDoc.getElementsByClassName("list-book-title")
         Worksheets("スクレイピング").Cells(i + 1, 2).Value = Str.innerHTML
@@ -31,12 +40,12 @@ Sub getBookdata()
 
 
     'URL
-    i = 1
     Dim GetUrl As String
     Dim GetUrlData() As String
     Dim GetUrlElement As Integer
     Dim GetID As Integer
-    
+
+    i = 1
     For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
         GetUrl = Str.getElementsByTagName("a")  'URL取得
         Worksheets("スクレイピング").Cells(i + 1, 4).Value = GetUrl  '取得URL反映
@@ -53,7 +62,6 @@ Sub getBookdata()
     Dim ActCell As Object '画像出力セル
 
     i = 1
-    
     For Each Img In htmlDoc.images '画像要素取得
         imgURL = Img.src '画像URL
         Set ActCell = Worksheets("スクレイピング").Cells(i + 1, 5)

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -1,7 +1,6 @@
 Attribute VB_Name = "Module_books"
 Option Explicit
 
-
 Sub getBookdata()
     Dim objIE As InternetExplorer 'IEオブジェクトを準備
     Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
@@ -26,7 +25,6 @@ Sub getBookdata()
     Dim GetID As Integer 'ID番号
     
     Dim imgURL As String '画像URL
-'    Dim imgURL As Variant '画像URL
     Dim Img As Variant '画像オブジェクト
     Dim ActCell As Object '画像出力セル
     
@@ -38,9 +36,6 @@ Sub getBookdata()
     ' book-table__listの要素をBookdataとして処理
     For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
     
-'        'Bookdata要素全体HTML(出力確認用)
-'        SWSheet.Cells(i + 1, 2).Value = Bookdata.innerHTML
-            
         '--detail部を取得してそれぞれ反映
             
             detailField = Bookdata.getElementsByClassName("book-table__list--detail") '--detailを取得
@@ -65,7 +60,6 @@ Sub getBookdata()
                 
         '画像処理
 
-'        Img = Bookdata.images '画像取得
         Img = Bookdata.getElementsByTagName("img")  '画像取得
         imgURL = Img.src '画像URL
         Set ActCell = SWSheet.Cells(i + 1, 5)
@@ -85,67 +79,11 @@ Sub getBookdata()
         
         '次のレコードの行番号
         i = i + 1
-'        If i > 1 Then Exit For
     Next Bookdata
-    
-'    ' シート上に指定クラスの全取得テキストを表示
-'    i = 1
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-title")
-'        Worksheets("スクレイピング").Cells(i + 1, 2).Value = Str.innerHTML
-'        i = i + 1
-'    Next Str
-'
-'    '書籍詳細
-'    i = 1
-'    For Each Str In htmlDoc.getElementsByClassName("list-book-detail")
-'        Worksheets("スクレイピング").Cells(i + 1, 3).Value = Str.innerHTML
-'        i = i + 1
-'    Next Str
-'
-'
-'    'URL
-'    Dim GetUrl As String
-'    Dim GetUrlData() As String
-'    Dim GetUrlElement As Integer
-'    Dim GetID As Integer
-'
-'    i = 1
-'    For Each Str In htmlDoc.getElementsByClassName("book-table__list--detail")
-'        GetUrl = Str.getElementsByTagName("a")  'URL取得
-'        Worksheets("スクレイピング").Cells(i + 1, 4).Value = GetUrl  '取得URL反映
-'        GetUrlData = Split(GetUrl, "/")  'URL要素取得
-'        GetUrlElement = UBound(GetUrlData)  'URL要素確認
-'        GetID = GetUrlData(GetUrlElement)  'URLから番号取得
-'        Worksheets("スクレイピング").Cells(i + 1, 1).Value = GetID  'ワークシートへ反映
-'        i = i + 1  '次の行指定
-'    Next Str
-'
-'    '画像用変数
-'    Dim imgURL As String '画像URL
-'    Dim Img As Object '画像オブジェクト
-'    Dim ActCell As Object '画像出力セル
-'
-'    i = 1
-'    For Each Img In htmlDoc.images '画像要素取得
-'        imgURL = Img.src '画像URL
-'        Set ActCell = Worksheets("スクレイピング").Cells(i + 1, 5)
-'
-'        '画像出力セルのピクセルを指定して表示
-'        Worksheets("スクレイピング").Shapes.AddPicture _
-'            fileName:=imgURL, _
-'                LinkToFile:=True, _
-'                    SaveWithDocument:=True, _
-'                    Left:=ActCell.Left, _
-'                    Top:=ActCell.Top, _
-'                    Width:=100, _
-'                    Height:=100
-'
-'        i = i + 1
-'    Next Img
-
 
     objIE.Quit 'objIEを終了させる
     MsgBox "データ取得が完了しました。"
+
 End Sub
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち


### PR DESCRIPTION
# WHAT
書籍情報取得コードをレコード単位に修正する
## VBAコード
Module_books.bas

# WHY
前回作成コードではカラム毎に全データを取得しExcel上へ表示していた。
レコード単位での処理に変更する為、レコードデータが格納されているクラスを指定して、スクレイピングを実施する方式へと変更した。
レコード単位取得から、各要素を取得しワークシート展開した、これによりForEachはレコード単位のみに適用することで、不要な繰り返しを削除した。
ワークシート指定を毎回実施していたので、専用変数を用意し、繰り返し記述をなくした。
画像取得をimagesとしていたが、レコードデータ取得情報には適用できない為、画像URL情報をタグ名指定で取得する方式に変更した。

レコード取得方式変更の為、Excel表示結果に変更はない。