### PR TITLE
書籍一覧情報取得、全ページ

### DIFF
--- a/Module_books.bas
+++ b/Module_books.bas
@@ -24,7 +24,7 @@ Sub getBookdata()
     Dim GetUrlElement As Integer 'URLSplit要素数
     Dim GetID As Integer 'ID番号
     
-    Dim imgURL As String '画像URL
+    Dim ImgURL As String '画像URL
     Dim Img As Variant '画像オブジェクト
     Dim ActCell As Object '画像出力セル
     
@@ -61,12 +61,12 @@ Sub getBookdata()
         '画像処理
 
         Img = Bookdata.getElementsByTagName("img")  '画像取得
-        imgURL = Img.src '画像URL
+        ImgURL = Img.src '画像URL
         Set ActCell = SWSheet.Cells(i + 1, 5)
 
         '画像出力セルのピクセルを指定して表示
         SWSheet.Shapes.AddPicture _
-            fileName:=imgURL, _
+            fileName:=ImgURL, _
                 LinkToFile:=True, _
                     SaveWithDocument:=True, _
                     Left:=ActCell.Left, _

--- a/Module_more_books.bas
+++ b/Module_more_books.bas
@@ -1,0 +1,80 @@
+Attribute VB_Name = "Module_more_books"
+Option Explicit
+
+Sub getBookdatas()
+
+    'オブジェクト設定
+        'IE
+        Dim objIE As InternetExplorer 'IEオブジェクトを準備
+        Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
+        objIE.Visible = True 'IEを表示
+        'HTML
+        Dim htmlDoc As HTMLDocument 'HTML全体
+        Dim Pagination As HTMLUListElement 'HTMLページネーション
+        Dim PagiLink As HTMLAnchorElement '次ページリンク
+        '作業ワークシート
+        Dim SWSheet As Worksheet 'ScrapingWorksheet
+        Set SWSheet = ThisWorkbook.Worksheets("テスト")
+        'データ取得URL
+        Dim OpenPage As String
+        OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
+        '繰り返し処理
+        Dim i As Integer
+        i = 1
+    
+    'OpenPageがある間はループして続ける
+    Do Until OpenPage = ""
+        
+        objIE.navigate OpenPage 'IEでURLを開く
+        
+        Call WaitResponse(objIE) '読み込み待ち
+        
+        Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+        
+        OpenPage = ""
+        
+        '書籍情報取得処理
+        Call getBookList(SWSheet, htmlDoc, i)
+        
+        'クラス名(pagination)の取得
+        Set Pagination = htmlDoc.getElementsByClassName("pagination")(0)
+        
+        If Not Pagination Is Nothing Then
+            'ページネーションがある場合は取得処理
+            For Each PagiLink In Pagination.getElementsByTagName("a")
+                If InStr(PagiLink.outerHTML, "rel=""next") > 0 Then
+                    OpenPage = PagiLink.href
+                End If
+            Next PagiLink
+        
+        End If
+        
+    Loop 'ループエンド
+
+    objIE.Quit 'objIEを終了させる
+    MsgBox "データ取得が完了しました。"
+
+End Sub
+
+Sub getBookList(SWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
+    
+    Dim Bookdata As HTMLDivElement 'レコード単位データ
+    Dim detailField As HTMLDivElement '詳細フィールドデータ
+    
+    For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
+        SWSheet.Cells(i + 1, 1).Value = i
+        
+        Set detailField = Bookdata.getElementsByClassName("book-table__list--detail")(0) '--detailを取得
+
+        SWSheet.Cells(i + 1, 2).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
+        i = i + 1
+    Next Bookdata
+
+End Sub
+
+Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
+    Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
+        DoEvents
+    Loop
+End Sub
+

--- a/Module_more_books.bas
+++ b/Module_more_books.bas
@@ -7,14 +7,14 @@ Sub getBookdatas()
         'IE
         Dim objIE As InternetExplorer 'IEオブジェクトを準備
         Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
-        objIE.Visible = True 'IEを表示
+        objIE.Visible = False 'IEを表示
         'HTML
         Dim htmlDoc As HTMLDocument 'HTML全体
         Dim Pagination As HTMLUListElement 'HTMLページネーション
         Dim PagiLink As HTMLAnchorElement '次ページリンク
         '作業ワークシート
         Dim SWSheet As Worksheet 'ScrapingWorksheet
-        Set SWSheet = ThisWorkbook.Worksheets("テスト")
+        Set SWSheet = ThisWorkbook.Worksheets("スクレイピング")
         'データ取得URL
         Dim OpenPage As String
         OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
@@ -61,12 +61,60 @@ Sub getBookList(SWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
     Dim Bookdata As HTMLDivElement 'レコード単位データ
     Dim detailField As HTMLDivElement '詳細フィールドデータ
     
-    For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
-        SWSheet.Cells(i + 1, 1).Value = i
-        
-        Set detailField = Bookdata.getElementsByClassName("book-table__list--detail")(0) '--detailを取得
+    Dim BookdataURL As String '詳細ページURL
+    Dim BookdataURLSplit() As String '詳細ページURL要素
+    Dim BookdataURLBound As Long 'URL要素数
+    Dim BookdataID As Integer 'ID番号
+    Dim BookdataImg As HTMLImg 'IMGタグ情報
+    Dim ImgURL As String '画像URL
+    Dim ActCell As Range '画像出力セル
 
-        SWSheet.Cells(i + 1, 2).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
+
+    For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
+        
+        '--detail情報からデータ取得
+        
+            '--detailを取得
+            Set detailField = Bookdata.getElementsByClassName("book-table__list--detail")(0)
+    
+            'タイトル名取得
+            SWSheet.Cells(i + 1, 2).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
+            
+            '詳細テキスト
+            SWSheet.Cells(i + 1, 3).Value = detailField.getElementsByClassName("list-book-detail")(0).innerText
+            
+            '詳細ページURL
+            BookdataURL = detailField.getElementsByTagName("a")(0) 'URL取得
+            SWSheet.Cells(i + 1, 4).Value = BookdataURL  '取得URL反映
+            
+            'Bookdata_ID取得
+            BookdataURLSplit = Split(BookdataURL, "/")  'URL要素分割
+            BookdataURLBound = UBound(BookdataURLSplit)  'URL要素数確認
+            BookdataID = BookdataURLSplit(BookdataURLBound)  'ID番号取得
+            SWSheet.Cells(i + 1, 1).Value = BookdataID
+        
+        '--detail情報からデータ取得ここまで
+        
+        
+        '画像処理
+
+            Set BookdataImg = Bookdata.getElementsByTagName("img")(0)  '画像取得
+            ImgURL = BookdataImg.src '画像URL
+            Set ActCell = SWSheet.Cells(i + 1, 5) '出力セル
+    
+            '画像出力セルのピクセルを指定して表示
+            SWSheet.Shapes.AddPicture _
+                fileName:=ImgURL, _
+                    LinkToFile:=True, _
+                        SaveWithDocument:=True, _
+                        Left:=ActCell.Left, _
+                        Top:=ActCell.Top, _
+                        Width:=100, _
+                        Height:=100
+
+        '画像処理ここまで
+        
+        '列番号処理
         i = i + 1
     Next Bookdata
 


### PR DESCRIPTION
# WHAT
書籍一覧をスクレイピングしてExcel上へ表示させる。
その際、ページネーションより次のページを取得し、全ページ取得できるようにする。

# WHY
HTMLを取得後、書籍一覧情報の取得については別のプロシージャとして切り出して作成。
書籍一覧取得処理完了後に、ページネーションURLを参照し、ある場合は次ページへと遷移し、同様の処理を繰り返すようにした。
書籍一覧取得・ページネーション処理の各々で作成していたVBAをベースとして、重複工程をそぎ落としてページネーション処理をベースとして作成している。
