### PR TITLE
詳細ページ情報取得

### DIFF
--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -20,7 +20,7 @@ Sub getBookdatasDatail()
         'データ取得URL
         Dim OpenPage As String
         OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
-        '繰り返し処理
+        'URL取得繰り返し処理
         Dim i As Integer
         i = 1
     
@@ -32,7 +32,7 @@ Sub getBookdatasDatail()
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
         OpenPage = "" 'データ取得URL初期化
         
-        
+
         '詳細ページURL取得
         Call getBookList(DWSheet, htmlDoc, i)
         
@@ -93,33 +93,41 @@ Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As Inter
     
     'データ取得URL
     Dim OpenPage As String
-    Dim htmlDoc As HTMLDocument 'HTML全体    Dim DocLavel As HTMLDivElement 'ラベル情報
-    Dim DocColumn As HTMLDivElementt 'column情報
+    Dim htmlDoc As HTMLDocument 'HTML全体
     Dim DocContent As HTMLDivElement 'HTMLコンテンツ処理
-    Dim i As Long
-
-    i = 1
+    Dim DocColumn As HTMLDivElement 'column情報
+    Dim i As Long, j As Long '書き出し用行列処理
+    i = 2
+        
+    Dim URLi As Long '詳細URL読み込み行番号処理
+    URLi = 1
+    
+    '初期文字列挿入
+    OpenPage = True
+    
     '詳細ページを開いて中のデータを取得
-        'テスト用に最初のURLだけ実施
-        OpenPage = DWSheet.Cells(1, 1).Value
+    Do Until OpenPage = ""
+        'URL取得
+        OpenPage = DWSheet.Cells(URLi, 1).Value
         
         objIE.navigate OpenPage 'IEでURLを開く
         Call WaitResponse(objIE) '読み込み待ち
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+        j = 1
         
         '詳細ページHTMLからデータ取得
         'document-contentを取得
         For Each DocContent In htmlDoc.getElementsByClassName("document-content")
-            SWSheet.Cells(i, 1).Value = DocContent.innerHTML
-            Set DocLavel = DocContent.getElementsByClassName("document-content__label")(0)
             Set DocColumn = DocContent.getElementsByClassName("document-content__column")(0)
-            If i <> 9 Then SWSheet.Cells(i, 2).Value = DocLavel.innerHTML
-            SWSheet.Cells(i, 3).Value = DocColumn.innerHTML
-            i = i + 1
+            SWSheet.Cells(i, j).Value = DocColumn.innerHTML
+            j = j + 1
         Next DocContent
         
     '詳細ページURL全取得で終了
-
+    i = i + 1
+    URLi = URLi + 1
+    Loop
+    
 End Sub
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -27,6 +27,9 @@ Sub getBookdatasDatail()
         'URLコレクション
         Dim URLCol As Collection
         Set URLCol = New Collection
+        
+        '処理完了メッセージ
+        Dim ExitMsg As String
 
     'OpenPageがある間はループして続ける
     Do Until OpenPage = ""
@@ -56,14 +59,23 @@ Sub getBookdatasDatail()
         
     Loop 'OpenPageループエンド
 
-
-    '取得した詳細ページURLから詳細ページ情報を取得する
-    Call getDetailBookdata(SWSheet, objIE, URLCol)
+'    Dim ExitMsg As String '処理完了メッセージ
+    
+    '詳細ページURLがなければ終了する
+    If URLCol.Count > 0 Then
+        Call getDetailBookdata(SWSheet, objIE, URLCol)
+        ExitMsg = "データ取得が完了しました。"
+    Else
+        ExitMsg = "取得データがありません"
+    End If
+'    '取得した詳細ページURLから詳細ページ情報を取得する
+'    Call getDetailBookdata(SWSheet, objIE, URLCol)
 
 
     'VBA終了処理
     objIE.Quit 'objIEを終了させる
-    MsgBox "データ取得が完了しました。"
+'    MsgBox "データ取得が完了しました。"
+    MsgBox ExitMsg
 
 End Sub
 

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -1,7 +1,7 @@
-Attribute VB_Name = "Module_more_books"
+Attribute VB_Name = "Module_PropetyDatas"
 Option Explicit
 
-Sub getBookdatas()
+Sub getBookdatasDatail()
 
     'オブジェクト設定
         'IE
@@ -15,6 +15,8 @@ Sub getBookdatas()
         '作業ワークシート
         Dim SWSheet As Worksheet 'ScrapingWorksheet
         Set SWSheet = ThisWorkbook.Worksheets("スクレイピング")
+        Dim DWSheet As Worksheet 'DetailWorksheet
+        Set DWSheet = ThisWorkbook.Worksheets("詳細ページ情報")
         'データ取得URL
         Dim OpenPage As String
         OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
@@ -26,17 +28,16 @@ Sub getBookdatas()
     Do Until OpenPage = ""
         
         objIE.navigate OpenPage 'IEでURLを開く
-        
         Call WaitResponse(objIE) '読み込み待ち
-        
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+        OpenPage = "" 'データ取得URL初期化
         
-        OpenPage = ""
+
+        '詳細ページURL取得
+        Call getBookList(DWSheet, htmlDoc, i)
         
-        '書籍情報取得処理
-        Call getBookList(SWSheet, htmlDoc, i)
         
-        'クラス名(pagination)の取得
+        'ページネーション処理
         Set Pagination = htmlDoc.getElementsByClassName("pagination")(0)
         
         If Not Pagination Is Nothing Then
@@ -49,27 +50,26 @@ Sub getBookdatas()
         
         End If
         
-    Loop 'ループエンド
+    Loop 'OpenPageループエンド
 
+
+    '取得した詳細ページURLから詳細ページ情報を取得する
+    Call getDetailBookdata(SWSheet, DWSheet)
+
+
+    'VBA終了処理
     objIE.Quit 'objIEを終了させる
     MsgBox "データ取得が完了しました。"
 
 End Sub
 
-Sub getBookList(SWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
+Sub getBookList(DWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
     
+    '詳細ページURLを取得
     Dim Bookdata As HTMLDivElement 'レコード単位データ
     Dim detailField As HTMLDivElement '詳細フィールドデータ
-    
     Dim BookdataURL As String '詳細ページURL
-    Dim BookdataURLSplit() As String '詳細ページURL要素
-    Dim BookdataURLBound As Long 'URL要素数
-    Dim BookdataID As Integer 'ID番号
-    Dim BookdataImg As HTMLImg 'IMGタグ情報
-    Dim ImgURL As String '画像URL
-    Dim ActCell As Range '画像出力セル
-
-
+    
     For Each Bookdata In htmlDoc.getElementsByClassName("book-table__list")
         
         '--detail情報からデータ取得
@@ -77,52 +77,26 @@ Sub getBookList(SWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
             '--detailを取得
             Set detailField = Bookdata.getElementsByClassName("book-table__list--detail")(0)
     
-            'タイトル名取得
-            SWSheet.Cells(i + 1, 2).Value = detailField.getElementsByClassName("list-book-title")(0).innerText
-            
-            '詳細テキスト
-            SWSheet.Cells(i + 1, 3).Value = detailField.getElementsByClassName("list-book-detail")(0).innerText
-            
             '詳細ページURL
             BookdataURL = detailField.getElementsByTagName("a")(0) 'URL取得
-            SWSheet.Cells(i + 1, 4).Value = BookdataURL  '取得URL反映
-            
-            'Bookdata_ID取得
-            BookdataURLSplit = Split(BookdataURL, "/")  'URL要素分割
-            BookdataURLBound = UBound(BookdataURLSplit)  'URL要素数確認
-            BookdataID = BookdataURLSplit(BookdataURLBound)  'ID番号取得
-            SWSheet.Cells(i + 1, 1).Value = BookdataID
-        
+            DWSheet.Cells(i, 1).Value = BookdataURL  '取得URL反映
         '--detail情報からデータ取得ここまで
-        
-        
-'        '画像処理
-'
-'            Set BookdataImg = Bookdata.getElementsByTagName("img")(0)  '画像取得
-'            ImgURL = BookdataImg.src '画像URL
-'            Set ActCell = SWSheet.Cells(i + 1, 5) '出力セル
-'
-'            '画像出力セルのピクセルを指定して表示
-'            SWSheet.Shapes.AddPicture _
-'                fileName:=ImgURL, _
-'                    LinkToFile:=True, _
-'                        SaveWithDocument:=True, _
-'                        Left:=ActCell.Left, _
-'                        Top:=ActCell.Top, _
-'                        Width:=100, _
-'                        Height:=100
-'
-'        '画像処理ここまで
         
         '列番号処理
         i = i + 1
     Next Bookdata
 
 End Sub
+Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet)
 
+    '詳細ページURLから詳細内容を取得
+
+End Sub
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
         DoEvents
     Loop
 End Sub
+
+
 

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -20,7 +20,7 @@ Sub getBookdatasDatail()
         'データ取得URL
         Dim OpenPage As String
         OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
-        'URL取得繰り返し処理
+        '繰り返し処理
         Dim i As Integer
         i = 1
     
@@ -32,7 +32,6 @@ Sub getBookdatasDatail()
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
         OpenPage = "" 'データ取得URL初期化
         
-
         '詳細ページURL取得
 '        Call getBookList(DWSheet, htmlDoc, i)
         
@@ -52,10 +51,9 @@ Sub getBookdatasDatail()
         
     Loop 'OpenPageループエンド
 
-
+    
     '取得した詳細ページURLから詳細ページ情報を取得する
     Call getDetailBookdata(SWSheet, DWSheet, objIE)
-
 
     'VBA終了処理
     objIE.Quit 'objIEを終了させる
@@ -111,18 +109,33 @@ Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As Inter
     Dim ImgURL As Variant
     Dim actcell As Variant
     
+    'ID取得
+    Dim GetUrl As String '詳細ページURL
+    Dim GetUrlData() As String '詳細ページURL,Splitデータ
+    Dim GetUrlElement As Integer 'URLSplit要素数
+    Dim GetID As Integer 'ID番号
+    
     '詳細ページを開いて中のデータを取得
     Do Until OpenPage = ""
         
         objIE.navigate OpenPage 'IEでURLを開く
         Call WaitResponse(objIE) '読み込み待ち
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
-        j = 2
+        j = 1
         
-        '画像取得処理
+        '1列目にID番号
+        '詳細ページURL
+        GetUrl = OpenPage 'URL取得
+        GetUrlData = Split(GetUrl, "/")  'URL要素取得
+        GetUrlElement = UBound(GetUrlData)  'URL要素確認
+        GetID = GetUrlData(GetUrlElement)  'URLから番号取得
+        SWSheet.Cells(i, j).Value = GetID
+        j = j + 1
+        
+        '2列目に画像
+        'book-detail__pictureを取得
         Set DocPicture = htmlDoc.getElementsByClassName("book-detail__picture")(0)
         Set ImgURL = DocPicture.getElementsByTagName("img")(0)
-        SWSheet.Cells(i, j).Value = ImgURL.src
         Set actcell = SWSheet.Cells(i, j)
         
         SWSheet.Shapes.AddPicture _
@@ -134,7 +147,8 @@ Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As Inter
             Width:=100, _
             Height:=100
         j = j + 1
-                
+        
+        '3列目以降にテキスト
         '詳細ページHTMLからデータ取得
         'document-contentを取得
         For Each DocContent In htmlDoc.getElementsByClassName("document-content")
@@ -157,4 +171,3 @@ Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
         DoEvents
     Loop
 End Sub
-

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -33,7 +33,7 @@ Sub getBookdatasDatail()
         OpenPage = "" 'データ取得URL初期化
         
         '詳細ページURL取得
-'        Call getBookList(DWSheet, htmlDoc, i)
+        Call getBookList(DWSheet, htmlDoc, i)
         
         
         'ページネーション処理
@@ -51,7 +51,7 @@ Sub getBookdatasDatail()
         
     Loop 'OpenPageループエンド
 
-    
+
     '取得した詳細ページURLから詳細ページ情報を取得する
     Call getDetailBookdata(SWSheet, DWSheet, objIE)
 
@@ -105,9 +105,12 @@ Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As Inter
     OpenPage = DWSheet.Cells(URLi, 1).Value
     
     '画像処理
-    Dim DocPicture As Variant
-    Dim ImgURL As Variant
-    Dim actcell As Variant
+'    Dim DocPicture As Variant
+'    Dim ImgURL As Variant
+'    Dim actcell As Variant
+    Dim DocPicture As HTMLDivElement
+    Dim ImgURL As HTMLImg
+    Dim actcell As Range
     
     'ID取得
     Dim GetUrl As String '詳細ページURL
@@ -166,6 +169,7 @@ Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As Inter
     Loop
     
 End Sub
+
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
         DoEvents

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -14,7 +14,7 @@ Sub getBookdatasDatail()
         Dim PagiLink As HTMLAnchorElement '次ページリンク
         '作業ワークシート
         Dim SWSheet As Worksheet 'ScrapingWorksheet
-        Set SWSheet = ThisWorkbook.Worksheets("スクレイピング")
+        Set SWSheet = ThisWorkbook.Worksheets("Sheet1")
         Dim DWSheet As Worksheet 'DetailWorksheet
         Set DWSheet = ThisWorkbook.Worksheets("詳細ページ情報")
         'データ取得URL
@@ -32,7 +32,7 @@ Sub getBookdatasDatail()
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
         OpenPage = "" 'データ取得URL初期化
         
-
+        
         '詳細ページURL取得
         Call getBookList(DWSheet, htmlDoc, i)
         
@@ -54,7 +54,7 @@ Sub getBookdatasDatail()
 
 
     '取得した詳細ページURLから詳細ページ情報を取得する
-    Call getDetailBookdata(SWSheet, DWSheet)
+    Call getDetailBookdata(SWSheet, DWSheet, objIE)
 
 
     'VBA終了処理
@@ -87,9 +87,38 @@ Sub getBookList(DWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
     Next Bookdata
 
 End Sub
-Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet)
+Sub getDetailBookdata(SWSheet As Worksheet, DWSheet As Worksheet, objIE As InternetExplorer)
 
     '詳細ページURLから詳細内容を取得
+    
+    'データ取得URL
+    Dim OpenPage As String
+    Dim htmlDoc As HTMLDocument 'HTML全体    Dim DocLavel As HTMLDivElement 'ラベル情報
+    Dim DocColumn As HTMLDivElementt 'column情報
+    Dim DocContent As HTMLDivElement 'HTMLコンテンツ処理
+    Dim i As Long
+
+    i = 1
+    '詳細ページを開いて中のデータを取得
+        'テスト用に最初のURLだけ実施
+        OpenPage = DWSheet.Cells(1, 1).Value
+        
+        objIE.navigate OpenPage 'IEでURLを開く
+        Call WaitResponse(objIE) '読み込み待ち
+        Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+        
+        '詳細ページHTMLからデータ取得
+        'document-contentを取得
+        For Each DocContent In htmlDoc.getElementsByClassName("document-content")
+            SWSheet.Cells(i, 1).Value = DocContent.innerHTML
+            Set DocLavel = DocContent.getElementsByClassName("document-content__label")(0)
+            Set DocColumn = DocContent.getElementsByClassName("document-content__column")(0)
+            If i <> 9 Then SWSheet.Cells(i, 2).Value = DocLavel.innerHTML
+            SWSheet.Cells(i, 3).Value = DocColumn.innerHTML
+            i = i + 1
+        Next DocContent
+        
+    '詳細ページURL全取得で終了
 
 End Sub
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
@@ -97,6 +126,3 @@ Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
         DoEvents
     Loop
 End Sub
-
-
-

--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -15,8 +15,6 @@ Sub getBookdatasDatail()
         '作業ワークシート
         Dim SWSheet As Worksheet 'ScrapingWorksheet
         Set SWSheet = ThisWorkbook.Worksheets("スクレイピング")
-'        Dim DWSheet As Worksheet 'DetailWorksheet
-'        Set DWSheet = ThisWorkbook.Worksheets("詳細ページ情報")
         'データ取得URL
         Dim OpenPage As String
         OpenPage = "https://protected-fortress-61913.herokuapp.com/book"
@@ -40,7 +38,6 @@ Sub getBookdatasDatail()
         OpenPage = "" 'データ取得URL初期化
         
         '詳細ページURL取得
-'        Call getBookList(DWSheet, htmlDoc, i, URLCol)
         Call getBookList(htmlDoc, i, URLCol)
         
         
@@ -59,7 +56,6 @@ Sub getBookdatasDatail()
         
     Loop 'OpenPageループエンド
 
-'    Dim ExitMsg As String '処理完了メッセージ
     
     '詳細ページURLがなければ終了する
     If URLCol.Count > 0 Then
@@ -68,13 +64,10 @@ Sub getBookdatasDatail()
     Else
         ExitMsg = "取得データがありません"
     End If
-'    '取得した詳細ページURLから詳細ページ情報を取得する
-'    Call getDetailBookdata(SWSheet, objIE, URLCol)
 
 
     'VBA終了処理
     objIE.Quit 'objIEを終了させる
-'    MsgBox "データ取得が完了しました。"
     MsgBox ExitMsg
 
 End Sub
@@ -95,8 +88,8 @@ Sub getBookList(htmlDoc As HTMLDocument, i As Integer, URLCol As Collection)
     
             '詳細ページURL
             BookdataURL = detailField.getElementsByTagName("a")(0) 'URL取得
-'            DWSheet.Cells(i, 1).Value = BookdataURL  '取得URL反映
             URLCol.Add BookdataURL
+        
         '--detail情報からデータ取得ここまで
         
         '列番号処理
@@ -120,12 +113,9 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
     Dim URLi As Long '詳細URL読み込み行番号処理
     URLi = 1
 
-    '最初のページ
-'    OpenPage = DWSheet.Cells(URLi, 1).Value
     'URL取得総数確認
     Dim fornumber As Long
     fornumber = URLCol.Count
-'    OpenPage = URLCol(URLi)
     
     '画像処理
     Dim DocPicture As HTMLDivElement
@@ -138,15 +128,10 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
     Dim GetUrlElement As Integer 'URLSplit要素数
     Dim GetID As Integer 'ID番号
 
-'    '動作確認用
-'    OpenPage = "test"
-
     '詳細ページを開いて中のデータを取得
-'    Do Until OpenPage = ""
     Do
         
         '次ページURL取得
-'        OpenPage = DWSheet.Cells(URLi, 1).Value
         OpenPage = URLCol(URLi)
         
         objIE.navigate OpenPage 'IEでURLを開く
@@ -154,8 +139,7 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
         Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
         j = 1
         
-        '1列目にID番号
-        '詳細ページURL
+        '1列目にID番号表示
         GetUrl = OpenPage 'URL取得
         GetUrlData = Split(GetUrl, "/")  'URL要素取得
         GetUrlElement = UBound(GetUrlData)  'URL要素確認
@@ -163,15 +147,9 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
         SWSheet.Cells(i, j).Value = GetID
         j = j + 1
         
-        '2列目に画像
-        'book-detail__pictureを取得
-'        For Each DocContent In htmlDoc.getElementsByClassName("book-detail__picture")
-'            Set test2 = DocContent.getElementsByTagName("IMG")(0)
-'            SWSheet.Cells(i, j).Value = test2.src
-'        Next DocContent
+        '2列目に画像表示
         Set DocPicture = htmlDoc.getElementsByClassName("book-detail__picture")(0)
         Set ImgURL = DocPicture.getElementsByTagName("img")(0)
-'        SWSheet.Cells(i, j).Value = ImgURL.src
         Set actcell = SWSheet.Cells(i, j)
         
         SWSheet.Shapes.AddPicture _
@@ -185,9 +163,7 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
         j = j + 1
         
         
-        '3列目以降にテキスト
-        '詳細ページHTMLからデータ取得
-        'document-contentを取得
+        '3列目以降にテキスト表示
         For Each DocContent In htmlDoc.getElementsByClassName("document-content")
             Set DocColumn = DocContent.getElementsByClassName("document-content__column")(0)
             SWSheet.Cells(i, j).Value = DocColumn.innerHTML
@@ -195,14 +171,15 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
         Next DocContent
         
         
-        '詳細ページURL全取得で終了
+        'カウント追加
         i = i + 1
         URLi = URLi + 1
         
+    'URL要素数を超える場合はループ終了
     Loop Until URLi > fornumber
-'    Loop
     
 End Sub
+
 Sub WaitResponse(objIE As Object) 'Webブラウザ表示完了待ち
     Do While objIE.Busy = True Or objIE.readyState < READYSTATE_COMPLETE '読み込み待ち
         DoEvents

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -19,7 +19,7 @@ Sub getBookdata()
     
     Dim Bookdata As Object 'レコード単位データ
     Dim detailField As Variant '詳細フィールドデータ
-    Dim GetUrl As String '詳細ページURL
+    Dim geturl As String '詳細ページURL
     Dim GetUrlData() As String '詳細ページURL,Splitデータ
     Dim GetUrlElement As Integer 'URLSplit要素数
     Dim GetID As Integer 'ID番号
@@ -48,9 +48,9 @@ Sub getBookdata()
             
             
             '詳細ページURL
-            GetUrl = detailField.getElementsByTagName("a") 'URL取得
-            SWSheet.Cells(i + 1, 4).Value = GetUrl  '取得URL反映
-            GetUrlData = Split(GetUrl, "/")  'URL要素取得
+            geturl = detailField.getElementsByTagName("a") 'URL取得
+            SWSheet.Cells(i + 1, 4).Value = geturl  '取得URL反映
+            GetUrlData = Split(geturl, "/")  'URL要素取得
             GetUrlElement = UBound(GetUrlData)  'URL要素確認
             GetID = GetUrlData(GetUrlElement)  'URLから番号取得
             SWSheet.Cells(i + 1, 1).Value = GetID

--- a/Module_books.bas
+++ b/Module_books.bas
@@ -19,7 +19,7 @@ Sub getBookdata()
     
     Dim Bookdata As Object 'レコード単位データ
     Dim detailField As Variant '詳細フィールドデータ
-    Dim geturl As String '詳細ページURL
+    Dim GetUrl As String '詳細ページURL
     Dim GetUrlData() As String '詳細ページURL,Splitデータ
     Dim GetUrlElement As Integer 'URLSplit要素数
     Dim GetID As Integer 'ID番号
@@ -48,9 +48,9 @@ Sub getBookdata()
             
             
             '詳細ページURL
-            geturl = detailField.getElementsByTagName("a") 'URL取得
-            SWSheet.Cells(i + 1, 4).Value = geturl  '取得URL反映
-            GetUrlData = Split(geturl, "/")  'URL要素取得
+            GetUrl = detailField.getElementsByTagName("a") 'URL取得
+            SWSheet.Cells(i + 1, 4).Value = GetUrl  '取得URL反映
+            GetUrlData = Split(GetUrl, "/")  'URL要素取得
             GetUrlElement = UBound(GetUrlData)  'URL要素確認
             GetID = GetUrlData(GetUrlElement)  'URLから番号取得
             SWSheet.Cells(i + 1, 1).Value = GetID

--- a/Module_more_books.bas
+++ b/Module_more_books.bas
@@ -96,23 +96,23 @@ Sub getBookList(SWSheet As Worksheet, htmlDoc As HTMLDocument, i As Integer)
         '--detail情報からデータ取得ここまで
         
         
-'        '画像処理
-'
-'            Set BookdataImg = Bookdata.getElementsByTagName("img")(0)  '画像取得
-'            ImgURL = BookdataImg.src '画像URL
-'            Set ActCell = SWSheet.Cells(i + 1, 5) '出力セル
-'
-'            '画像出力セルのピクセルを指定して表示
-'            SWSheet.Shapes.AddPicture _
-'                fileName:=ImgURL, _
-'                    LinkToFile:=True, _
-'                        SaveWithDocument:=True, _
-'                        Left:=ActCell.Left, _
-'                        Top:=ActCell.Top, _
-'                        Width:=100, _
-'                        Height:=100
-'
-'        '画像処理ここまで
+        '画像処理
+
+            Set BookdataImg = Bookdata.getElementsByTagName("img")(0)  '画像取得
+            ImgURL = BookdataImg.src '画像URL
+            Set ActCell = SWSheet.Cells(i + 1, 5) '出力セル
+
+            '画像出力セルのピクセルを指定して表示
+            SWSheet.Shapes.AddPicture _
+                fileName:=ImgURL, _
+                    LinkToFile:=True, _
+                        SaveWithDocument:=True, _
+                        Left:=ActCell.Left, _
+                        Top:=ActCell.Top, _
+                        Width:=100, _
+                        Height:=100
+
+        '画像処理ここまで
         
         '列番号処理
         i = i + 1


### PR DESCRIPTION
# WHAT
書籍一覧情報から詳細ページURLを取得し、詳細ページからより多くの情報をExcelワークシートへスクレイピングできるようにする。

# WHY
書籍一覧表示から取得していたデータを詳細ページURL取得のみに変更。
取得したURL一覧をコレクション変数に格納し、URL毎に詳細ページにアクセスを実施。
アクセスした詳細ページから、書籍情報を取得することにより、書籍一覧よりも多くの情報を収集できるようにした。
データ収集の手順については、一覧取得時と同様であり、対象となるクラス名を変更することで、取得要素を指定した。
![VBA-詳細取得09](https://user-images.githubusercontent.com/45278393/59736941-af946b00-9296-11e9-8a0d-158df9874b7f.JPG)
