### PR TITLE
ISBNコード全件登録

### DIFF
--- a/Module_inputSomeBookdataISBN.bas
+++ b/Module_inputSomeBookdataISBN.bas
@@ -17,13 +17,18 @@ Sub inputSomeBookdataISBN()
         '登録ISBN
         Dim InputISBN As Collection 'データ取得
         Set InputISBN = New Collection
-        Dim EntryISBN As String 'フォーム入力用csv
-        Const LimitEntry As Integer = 20 'フォーム入力ISBN上限
+        Dim ISBNAllCount As Integer 'ISBN総数
+        Const LimitEntry As Integer = 3 'フォーム入力ISBN上限
+        Dim EntryISBN() As String 'フォーム入力用csv(上限毎)
+        Dim MaxRepeat As Long 'ISBN処理回数
+        Dim LastISBNCount As Integer '最終ISBN件数
+        Dim ElementCounter As Long '要素取得カウンタ
         'データ取得URL
         Dim InputISBNPage As String
         InputISBNPage = "https://protected-fortress-61913.herokuapp.com/book/isbn_some_input"
         '繰り返し処理
         Dim i As Integer
+        Dim j As Integer
         i = 2
         '処理完了メッセージ
         Dim ExitMsg As String
@@ -38,25 +43,47 @@ Sub inputSomeBookdataISBN()
         InputISBN.Add ISSheet.Cells(i, 2).Value
         i = i + 1
     Loop
+    ISBNAllCount = InputISBN.Count 'ISBNコード総数
 
-    'カンマ区切りテキスト生成(全ISBN or 上限件数まで)
-    i = 1 '繰り返し変数初期化
-    Do
-        EntryISBN = EntryISBN & InputISBN(i)
-        If i <> InputISBN.Count Then EntryISBN = EntryISBN & ","
-        i = i + 1
-    Loop Until i > InputISBN.Count Or i > LimitEntry
-
-    'フォーム入力
-    htmlDoc.getElementsByClassName("form-input__detail")(0).Value = EntryISBN
-    htmlDoc.getElementsByClassName("send isbn")(0).Click
-
-    'フォーム結果HTML取得
-    Call WaitResponse(objIE) '読み込み待ち
-    Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+    'Web上限毎に登録処理をするカンマ区切りテキストを準備
     
-    'フォーム処理結果取得
-    Call getISBNAnswers(htmlDoc, ISSheet)
+        'ISBN処理回数算出
+        MaxRepeat = Application.RoundUp(ISBNAllCount / LimitEntry, 0) '繰り返し回数
+        LastISBNCount = ISBNAllCount Mod LimitEntry '繰り返しラスト取得件数
+        ElementCounter = 1 '要素取得カウンタ初期値
+        ReDim EntryISBN(MaxRepeat - 1) '配列としてISBN格納
+        
+        'Web処理上限毎に処理できるようにする
+        For j = 0 To MaxRepeat - 1
+        
+            i = 1 '繰り返し変数初期化
+            'カンマ区切りテキスト生成(全ISBN or 上限件数まで)
+            Do
+                EntryISBN(j) = EntryISBN(j) & InputISBN(ElementCounter) 'ISBNコードを要素として追加
+                '処理上限orISBN総数ラストはカンマなし
+                If ElementCounter <> ISBNAllCount And i <> LimitEntry Then EntryISBN(j) = EntryISBN(j) & ","
+                ElementCounter = ElementCounter + 1
+                i = i + 1
+            Loop Until i > LimitEntry Or ElementCounter > ISBNAllCount
+        Next j
+        
+    '全件処理完了まで繰り返し
+        
+    'カンマ区切りテキストを全て反映させる
+        i = 2 '結果出力テキスト挿入位置初期化
+        
+        'フォーム入力
+        htmlDoc.getElementsByClassName("form-input__detail")(0).Value = EntryISBN(0)
+        htmlDoc.getElementsByClassName("send isbn")(0).Click
+    
+        'フォーム結果HTML取得
+        Call WaitResponse(objIE) '読み込み待ち
+        Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
+        
+        'フォーム処理結果取得
+        Call getISBNAnswers(htmlDoc, ISSheet, i)
+
+    '全件処理完了まで繰り返し
 
     'VBA終了処理
     objIE.Quit 'objIEを終了させる
@@ -65,14 +92,12 @@ Sub inputSomeBookdataISBN()
 
 End Sub
 
-Sub getISBNAnswers(htmlDoc As HTMLDocument, ISSheet As Worksheet)
+Sub getISBNAnswers(htmlDoc As HTMLDocument, ISSheet As Worksheet, i As Integer)
     
     '結果処理変数
     Dim ResultRecord As HTMLDivElement 'Record単位データ
     Dim ResultTitle As HTMLDivElement 'タイトル名
     Dim ResultText As HTMLDivElement '結果テキスト
-    Dim i As Long
-    i = 2
     
     For Each ResultRecord In htmlDoc.getElementsByClassName("isbn-result__box")
     

--- a/Module_inputSomeBookdataISBN.bas
+++ b/Module_inputSomeBookdataISBN.bas
@@ -18,7 +18,7 @@ Sub inputSomeBookdataISBN()
         Dim InputISBN As Collection 'データ取得
         Set InputISBN = New Collection
         Dim ISBNAllCount As Integer 'ISBN総数
-        Const LimitEntry As Integer = 3 'フォーム入力ISBN上限
+        Const LimitEntry As Integer = 20 'フォーム入力ISBN上限
         Dim EntryISBN() As String 'フォーム入力用csv(上限毎)
         Dim MaxRepeat As Long 'ISBN処理回数
         Dim LastISBNCount As Integer '最終ISBN件数
@@ -33,11 +33,6 @@ Sub inputSomeBookdataISBN()
         '処理完了メッセージ
         Dim ExitMsg As String
         
-    'URLを開いてオブジェクト取得
-    objIE.navigate InputISBNPage 'IEでURLを開く
-    Call WaitResponse(objIE) '読み込み待ち
-    Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
-
     'ISBNコード取得
     Do Until ISSheet.Cells(i, 2).Value = ""
         InputISBN.Add ISSheet.Cells(i, 2).Value
@@ -50,8 +45,8 @@ Sub inputSomeBookdataISBN()
         'ISBN処理回数算出
         MaxRepeat = Application.RoundUp(ISBNAllCount / LimitEntry, 0) '繰り返し回数
         LastISBNCount = ISBNAllCount Mod LimitEntry '繰り返しラスト取得件数
+        ReDim EntryISBN(MaxRepeat - 1) '配列として要素指定して再宣言
         ElementCounter = 1 '要素取得カウンタ初期値
-        ReDim EntryISBN(MaxRepeat - 1) '配列としてISBN格納
         
         'Web処理上限毎に処理できるようにする
         For j = 0 To MaxRepeat - 1
@@ -70,10 +65,17 @@ Sub inputSomeBookdataISBN()
     '全件処理完了まで繰り返し
         
     'カンマ区切りテキストを全て反映させる
-        i = 2 '結果出力テキスト挿入位置初期化
+    i = 2 '結果出力テキスト挿入位置初期化
+        
+    For j = 0 To MaxRepeat - 1
+        
+        'フォームを開く
+        objIE.navigate InputISBNPage 'IEでURLを開く
+        Call WaitResponse(objIE) '読み込み待ち
+        Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
         
         'フォーム入力
-        htmlDoc.getElementsByClassName("form-input__detail")(0).Value = EntryISBN(0)
+        htmlDoc.getElementsByClassName("form-input__detail")(0).Value = EntryISBN(j)
         htmlDoc.getElementsByClassName("send isbn")(0).Click
     
         'フォーム結果HTML取得
@@ -82,6 +84,7 @@ Sub inputSomeBookdataISBN()
         
         'フォーム処理結果取得
         Call getISBNAnswers(htmlDoc, ISSheet, i)
+    Next j
 
     '全件処理完了まで繰り返し
 


### PR DESCRIPTION
# WHAT
Web登録上限を超えるISBNを指定しても全件登録できるようにする。

# WHY
本VBA作成時点でのWeb登録上限は20件となっているが、この件数を超過するISBNコード登録リスエスとをした時に20件毎に分割して全て登録を実施できるようにする。