### PR TITLE
書籍削除結果の表示

### DIFF
--- a/Module_deleteBookDataID.bas
+++ b/Module_deleteBookDataID.bas
@@ -7,7 +7,8 @@ Sub deleteBookdataISBN()
         'IE
         Dim objIE As InternetExplorer 'IEオブジェクトを準備
         Set objIE = CreateObject("Internetexplorer.Application") '新しいIEオブジェクトを作成してセット
-        objIE.Visible = False 'IEを表示
+        objIE.Visible = True 'IEを表示
+'        objIE.Visible = False 'IEを表示
         'HTML
         Dim htmlDoc As HTMLDocument 'HTML全体
         '作業ワークシート
@@ -19,6 +20,7 @@ Sub deleteBookdataISBN()
         'データ取得URL
         Dim DelBookPageBase As String
         Dim DelBookPage As String
+        Dim DelBookURL As String
         DelBookPageBase = "https://protected-fortress-61913.herokuapp.com/book/"
         '繰り返し処理
         Dim i As Integer
@@ -48,18 +50,30 @@ Sub deleteBookdataISBN()
             Call WaitResponse(objIE) '読み込み待ち
             Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
     
+            '存在しないページに対しての処理
+            
             '書籍を消す
             htmlDoc.getElementsByClassName("nav-btn delete")(0).Click
-            i = i + 1
+            '削除後の処理
+            Call WaitResponse(objIE) '読み込み待ち
+            DelBookURL = objIE.document.URL & "/" '読み込み後のURL取得
+            
+            If DelBookURL = DelBookPageBase Then
+                DelBookSheet.Cells(i + 1, 2).Value = "削除しました"
+            Else
+                DelBookSheet.Cells(i + 1, 2).Value = "削除できませんでした"
+            End If
+            
+            i = i + 1 '次データ処理開始準備
         Loop Until i > DelID.Count
         
-        ExitMsg = "書籍情報を削除しました"
+        ExitMsg = "削除処理が完了しました"
     
     End If
         
 
     'VBA終了処理
-    objIE.Quit 'objIEを終了させる
+'    objIE.Quit 'objIEを終了させる
     MsgBox ExitMsg
 
 End Sub

--- a/Module_deleteBookDataID.bas
+++ b/Module_deleteBookDataID.bas
@@ -43,15 +43,27 @@ Sub deleteBookdataISBN()
     Else
         
         i = 1 '繰り返し初期化
+        Dim objHTTP As Object 'HTTPチェック用オブジェクト
+        Dim HTTPStatus As Integer
         Do
-            DelBookPage = DelBookPageBase & DelID(i)
+            DelBookPage = DelBookPageBase & DelID(i) '削除書籍URL取得
+            
+            'URL指定先の確認
+            Set objHTTP = CreateObject("MSXML2.XMLHTTP") 'IXMLHTTPRequestオブジェクト生成(ライブラリなし)
+            objHTTP.Open "HEAD", DelBookPage, False 'IXMLHTTPRequestオブジェクト初期化
+            objHTTP.send 'IXMLHTTPRequestリクエスト送信
+            Do While objHTTP.readyState < READYSTATE_COMPLETE '読み込み待ち
+                DoEvents
+            Loop
+            HTTPStatus = objHTTP.Status 'HTTPリクエスト結果格納
+        
+            
+            
             'URLを開いてオブジェクト取得
             objIE.navigate DelBookPage 'IEでURLを開く
             Call WaitResponse(objIE) '読み込み待ち
             Set htmlDoc = objIE.document 'objIEで読み込まれているHTMLドキュメントをセット
-    
-            '存在しないページに対しての処理
-            
+                
             '書籍を消す
             htmlDoc.getElementsByClassName("nav-btn delete")(0).Click
             '削除後の処理


### PR DESCRIPTION
# WHAT
VBAによる書籍情報削除結果をワークシートに表示する
削除済み書籍や、存在しないIDを指定するとエラーとなるので、対処をを併せて行う。

# WHY
## 削除結果表示について
削除処理自体は以前作成済みである。
削除後のWebページ遷移状態が削除処理結果によって異なる為、削除後のURLにて結果判断するように作成した。
削除後書籍一覧にアクセスした場合は、削除は完了しているので削除できた旨のメッセージを表示。
削除できなかった場合は書籍詳細ページ画面のままエラーメッセージが表示される為、URLに変化がない場合は削除できなかった旨のメッセージをワークシートへ出力するように作成した。
## 削除処理エラー対処について
削除処理は対象書籍詳細ページへアクセスして削除ボタンを押下して削除を実施していた。
しかし、存在しないIDへアクセスした場合、ボタンはないためエラーとなりVBAが中断されていた。
そのため、削除処理前にgetメソッドリクエストによるサイト状態確認を行い、処理分岐を追加した。
分岐後、リクエストが正常に帰ってきた場合は、従来の削除処理を実施。
リクエストに問題がある場合は、処理結果にエラーの文字を返し、HTTPリクエストのエラーコードも併せて表示させるようにした。
