### PR TITLE
画像オブジェクト名を指定する

### DIFF
--- a/Module_PropetyDatas.bas
+++ b/Module_PropetyDatas.bas
@@ -171,6 +171,10 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
     Dim GetUrlElement As Integer 'URLSplit要素数
     Dim GetID As Integer 'ID番号
 
+    '画像オブジェクト処理
+    Dim objCount As Long 'オブジェクト総数
+    objCount = SWSheet.Shapes.Count '総数取得
+    
     '詳細ページを開いて中のデータを取得
     Do
         i = i + 1
@@ -202,6 +206,9 @@ Sub getDetailBookdata(SWSheet As Worksheet, objIE As InternetExplorer, URLCol As
             Top:=ActCell.Top, _
             Width:=100, _
             Height:=100
+        '画像名付与
+        objCount = objCount + 1 '新規オブジェクト指定
+        ActiveSheet.Shapes(objCount).Name = GetID 'ID名を付与
         j = j + 1
         
         '3列目以降にテキスト表示

--- a/Module_getURLtest.bas
+++ b/Module_getURLtest.bas
@@ -153,3 +153,25 @@ End Sub
 '    Loop
 'End Sub
 
+'ワークシート内オブジェクト取得テスト
+Sub testobjname()
+    Dim strObjName() As String
+    Dim intObj As Integer
+    Dim i As Integer
+
+    'アクティブシートのShapes数をカウント
+    intObj = ActiveSheet.Shapes.Count
+    '配列を再宣言
+    ReDim strObjName(intObj)
+
+    '配列strObjNameにオブジェクト名を代入
+    For i = 1 To intObj
+        strObjName(i) = ActiveSheet.Shapes(i).Name
+    Next i
+
+    '配列strObjNameに代入されたオブジェクト名を表示
+    For i = 1 To intObj
+'        MsgBox strObjName(i)
+        Debug.Print strObjName(i)
+    Next i
+End Sub


### PR DESCRIPTION
# WHAT
書籍情報詳細取得時に書籍画像オブジェクトに対して、ID名を付与する。

# WHY
新規画像取得時に、オブジェクトを指定して書籍IDと同様の名前を付与出来るようにした。